### PR TITLE
B60-ZK-1142: Second level menuitem onclick event not fired on iPad

### DIFF
--- a/zk/src/archive/web/js/zk/domtouch.js
+++ b/zk/src/archive/web/js/zk/domtouch.js
@@ -276,7 +276,7 @@ zk.override(jq.fn, _jq, {
 				}
 			}
 		} else
-			this.zbind(type, data, fn);
+			this.zbind.apply(this, arguments); // Bug ZK-1142: recove back to latest domios.js
 			
 		return this;
 	},
@@ -300,7 +300,7 @@ zk.override(jq.fn, _jq, {
 				}
 			}
 		} else
-			this.zunbind(type, fn);
+			this.zunbind.apply(this, arguments); // Bug ZK-1142: recove back to latest domios.js
 		return this;
 	}
 });

--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -9,6 +9,7 @@ ZK 6.0.2
   ZK-1136: Clients.showNotification(String) throws JS error when used with Include in defer mode
   ZK-1135: Notification is not correctly displayed on IE8 (compatibility view turned OFF)
   ZK-1144: error-page in JBoss causes IllegalStateException
+  ZK-1142: Second level menuitem onclick event not fired on iPad
 
 * Upgrade Notes
 

--- a/zktest/src/archive/test2/B60-ZK-1142.zul
+++ b/zktest/src/archive/test2/B60-ZK-1142.zul
@@ -1,0 +1,25 @@
+<zk>
+	<window id="win_main" title="Hello IPad!!" border="normal" width="100%">
+		<vlayout>
+			<label>1. Try selecting New >> Document/Spreadsheet/Presentation.</label>
+			<label>2. You should see alert message displayed</label>
+		</vlayout>
+		<menubar id="menubar" width="100%">
+			<menu label="File">
+				<menupopup>
+					<menu label="New" style="cursor :pointer">
+						<menupopup id="m" style="cursor :pointer">
+							<menuitem label="Document" style="cursor :pointer" onClick="alert(self.label)" />
+							<menuitem label="Spreadsheet" style="cursor:pointer" onClick="alert(self.label)" />
+							<menuitem label="Presentation" style="cursor:pointer" onClick="alert(self.label)" />
+						</menupopup>
+					</menu>
+					<menuitem label="Open.." onClick="alert(self.label)" />
+					<menuseparator></menuseparator>
+					<menuitem label="Save" onClick="alert(self.label)" />
+				</menupopup>
+			</menu>
+			<menuitem label="ZK Web Framework" onClick="alert(self.label)" />
+		</menubar>
+	</window>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -1380,6 +1380,7 @@ B60-ZK-1100.zul=A,E,Menuitem
 B60-ZK-1113.zul=B,E,Chosenbox,EE
 B60-ZK-1136.zul=B,M.Notification
 B60-ZK-1135.zul=B,E,Notification,CSS,IE8
+B60-ZK-1142.zul=B,M,Menu,iPad
 
 ##
 # Features - 3.0.x version


### PR DESCRIPTION
http://www.zkoss.org/services/zk/tracker/?ZK-1142
