### PR TITLE
B50-ZK-1143: Subsequent WrongValueException causes JS error on ipad

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -24,6 +24,7 @@ ZK 5.0.12
   ZK-1118: Vertical scrollbar appears when listbox with fixed rows and sizedByContent is true exceeds browser width
   ZK-1144: error-page in JBoss causes IllegalStateException
   ZK-1129: Listbox content did not match the outline border (IE7 only)
+  ZK-1143: Subsequent WrongValueException causes JS error on ipad
   
 	--------
 ZK 5.0.11

--- a/zktest/src/archive/test2/B50-ZK-1143.zul
+++ b/zktest/src/archive/test2/B50-ZK-1143.zul
@@ -1,0 +1,20 @@
+<zk>
+	<zscript>int i = 0;</zscript>
+	<vlayout spacing="2px">
+		<label>1. iPad only</label>
+		<label>2. Click "update" button twice</label>
+		<label>3. You should not see javascrip error</label>
+		<hlayout spacing="2px">
+			<label value="first name"/>: <textbox id="txt_fname"/>
+		</hlayout>
+		<button label="update">
+			<attribute name="onClick"><![CDATA[
+		 		times.setValue("click " + ++i + " times");
+		 		if (org.zkoss.lang.Strings.isBlank(txt_fname.getValue())) {
+		 			throw new WrongValueException(txt_fname, "first name required!");
+		 		}
+			]]></attribute>
+		</button>
+		<label id="times"></label>
+	</vlayout>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -1316,6 +1316,7 @@ B50-ZK-1079.zul=A,M,FullMask,Fileupload,ZIndex
 B50-ZK-1086.zul=A,E,Datebox,DateFormat
 B50-ZK-1092.zul=A,H,revisedOffset,IE8
 B50-ZK-1118.zul=A,M,Listbox,Tree,sizedByContent,rows
+B50-ZK-1143.zul=A,M,Errorbox,Mobile
 
 ##
 # Features - 3.0.x version

--- a/zul/src/archive/web/js/zul/inp/Errorbox.js
+++ b/zul/src/archive/web/js/zul/inp/Errorbox.js
@@ -74,7 +74,10 @@ zul.inp.Errorbox = zk.$extends(zul.wgt.Popup, {
 		zWatch.listen({onScroll: this});
 	},
 	unbind_: function () {
-		this._drag.destroy();
+		// bug ZK-1143
+		var drag = this._drag;
+		this._drag = null;
+		drag.destroy();
 		zWatch.unlisten({onScroll: this});
 		
 		// just in case


### PR DESCRIPTION
http://www.zkoss.org/services/zk/tracker/?ZK-1143
