### PR TITLE
B60-ZK-1146: TreeModel getChildCount invoke too much times

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -10,6 +10,7 @@ ZK 6.0.2
   ZK-1135: Notification is not correctly displayed on IE8 (compatibility view turned OFF)
   ZK-1144: error-page in JBoss causes IllegalStateException
   ZK-1142: Second level menuitem onclick event not fired on iPad
+  ZK-1146: TreeModel getChildCount invoke too much times
 
 * Upgrade Notes
 

--- a/zul/src/org/zkoss/zul/Tree.java
+++ b/zul/src/org/zkoss/zul/Tree.java
@@ -1630,7 +1630,7 @@ public class Tree extends MeshElement {
 	 */
 	private void renderChildren(Renderer renderer, Treechildren parent,
 	Object node) throws Throwable {
-		for(int i = 0; i < _model.getChildCount(node); i++) {
+		for (int i = 0, j = _model.getChildCount(node); i < j; i++) {
 			Treeitem ti = newUnloadedItem();
 			ti.setParent(parent);
 			Object childNode = _model.getChild(node, i);


### PR DESCRIPTION
for ZK6, the issue is the same as B50-ZK-1146
