### PR TITLE
B60-ZK-1147: The returning type of getModel API in combobox and tree component shall be the same 

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -12,6 +12,7 @@ ZK 6.0.2
   ZK-1143: Subsequent WrongValueException causes JS error on ipad
   ZK-1142: Second level menuitem onclick event not fired on iPad
   ZK-1146: TreeModel getChildCount invoke too much times
+  ZK-1147: The returning type of getModel API in combobox and tree component shall be the same
 
 * Upgrade Notes
 

--- a/zul/src/org/zkoss/zul/Combobox.java
+++ b/zul/src/org/zkoss/zul/Combobox.java
@@ -143,8 +143,8 @@ public class Combobox extends Textbox {
 	 * @since 3.0.2
 	 * @see ListSubModel#getSubModel(Object, int)
 	 */
-	public ListModel<?> getModel() {
-		return _model;
+	public <T> ListModel<T> getModel() {
+		return (ListModel)_model;
 	}
 	/** Sets the list model associated with this combobox.
 	 * If a non-null model is assigned, no matter whether it is the same as

--- a/zul/src/org/zkoss/zul/Radiogroup.java
+++ b/zul/src/org/zkoss/zul/Radiogroup.java
@@ -354,8 +354,8 @@ public class Radiogroup extends XulElement {
 	 * if this radiogroup is not associated with any list data model.
 	 * @since 6.0.0
 	 */
-	public ListModel<?> getModel() {
-		return _model;
+	public <T> ListModel<T> getModel() {
+		return (ListModel)_model;
 	}
 	/** Sets the list model associated with this radiogroup.
 	 * If a non-null model is assigned, no matter whether it is the same as


### PR DESCRIPTION
http://tracker.zkoss.org/browse/ZK-1147
also fix the same problem in org.zkoss.zul.Radiogroup
