### PR TITLE
B50-ZK-1179: ZK Internationalization Labels doesn't work with liferay (portal env)

### DIFF
--- a/zk/src/org/zkoss/zk/ui/http/DHtmlLayoutPortlet.java
+++ b/zk/src/org/zkoss/zk/ui/http/DHtmlLayoutPortlet.java
@@ -141,10 +141,19 @@ public class DHtmlLayoutPortlet extends GenericPortlet {
 		}
 		SessionsCtrl.setCurrent(sess);
 		try {
-			if (!process(sess, request, response, path, bRichlet))
-				handleError(sess, request, response, path, null, null);
-		} catch (Throwable ex) {
-			handleError(sess, request, response, path, ex, null);
+			// Bug ZK-1179: process I18N in portlet environment
+			HttpServletRequest httpreq = RenderHttpServletRequest.getInstance(request);
+			HttpServletResponse httpres = RenderHttpServletResponse.getInstance(response);
+			final Object old = I18Ns.setup(httpreq.getSession(), httpreq, httpres,
+				sess.getWebApp().getConfiguration().getResponseCharset());
+			try {
+				if (!process(sess, request, response, path, bRichlet))
+					handleError(sess, request, response, path, null, null);
+			} catch (Throwable ex) {
+				handleError(sess, request, response, path, ex, null);
+			} finally {
+				I18Ns.cleanup(httpreq, old);
+			}
 		} finally {
 			SessionsCtrl.requestExit(sess);
 			SessionsCtrl.setCurrent((Session)null);

--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -26,6 +26,7 @@ ZK 5.0.12
   ZK-1129: Listbox content did not match the outline border (IE7 only)
   ZK-1143: Subsequent WrongValueException causes JS error on ipad
   ZK-1146: TreeModel getChildCount invoke too much times
+  ZK-1179: ZK Internationalization Labels doesn't work with liferay (portal env)
   
 	--------
 ZK 5.0.11

--- a/zktest/src/archive/test2/B50-ZK-1179.zul
+++ b/zktest/src/archive/test2/B50-ZK-1179.zul
@@ -1,0 +1,6 @@
+<zk xmlns:n="native">
+	<n:h3>Liferay Portlet only</n:h3>
+	<window title="${labels.username}" width="400px">
+		Change your browser's preferred language to Chinese(zh-TW) and reload, you should see the window title changed.
+	</window>
+</zk>


### PR DESCRIPTION
http://tracker.zkoss.org/browse/ZK-1179
