### PR TITLE
Bug fix B60-ZK-1177

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -18,6 +18,7 @@ ZK 6.0.2
   ZK-1124: onOpen event not firing when closing a Menupopup
   ZK-1165: Inner ViewMdel cannot get Outer ViewModel in Binding
   ZK-1164: "content" attribute in <image> can't handle the RenderedImage type with MVVM
+  ZK-1177: SimpleListModelSharer causes NullPointerException when the model is updated
   ZK-1178: ZEL should support method overloading
   ZK-1191: Children binding converter doesn't converter a pure Collection
   ZK-1189: Save into a deep form bean fires improper NotifyChange

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -1384,6 +1384,7 @@ B60-ZK-1135.zul=B,E,Notification,CSS,IE8
 B60-ZK-1142.zul=B,M,Menu,iPad
 B60-ZK-1159.zul=A,M,Listbox,ROD,Model
 B60-ZK-1124.zul=B,E,Menupopup
+B60-ZK-1177.zul=B,E,SimpleListModelSharer,PE,EE
 B60-ZK-1178.zul=A,E,MVVM,DataBinding
 
 ##


### PR DESCRIPTION
SimpleListModelSharer causes NullPointerException when model is updated.

Signed-off-by: Neil Lee neillee@potix.com

Please refer to zkcml for the actual code change.
