### PR TITLE
Bug ZK-1314: input component focus in modal window causes virtual keyboard to show up and down on iPad

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -29,6 +29,7 @@ ZK 6.5.0
 * Bugs
   ZK-1285: Modal window position issue with virtual keyboard on ipad
   ZK-1313: combobox dropdown changes document scroll height on iPad
+  ZK-1314: input component focus in modal window causes virtual keyboard to show up and down on iPad
 
 * Upgrade Notes
   + Rename the "tbbtn" mold of chosenbox to "toolbar"

--- a/zktest/src/archive/test2/B65-ZK-1314.zul
+++ b/zktest/src/archive/test2/B65-ZK-1314.zul
@@ -1,0 +1,17 @@
+<zk>
+	<textbox />
+	<button label="click me" onClick='alert("Clicked")' />
+	<window id="subWin" mode="modal" width="500px" height="500px"
+		closable="true" title="Wizard" border="normal">
+		<groupbox>
+			<caption>Wizard</caption>
+			<vlayout>
+				<textbox value="Enter value"></textbox>
+				<combobox>
+					<comboitem label="United Nations (UN)" />
+					<comboitem label="North America (NA)" />
+				</combobox>
+			</vlayout>
+		</groupbox>
+	</window>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -1399,7 +1399,8 @@ B60-ZK-1303.zul=B,M,Listbox,Select
 
 #ZK6.5
 B65-ZK-1285.zul=B,M,Input,Modal,Window,iPad
-B65-ZK-1313.zul=B,M,Combobox,ModalWindow,iPad,Android
+B65-ZK-1313.zul=B,M,Combobox,ModalWindow,iPad
+B65-ZK-1314.zul=B,M,ModalWindow,focus,iPad,Android
 
 ##
 # Features - 3.0.x version

--- a/zul/src/archive/web/js/zul/wnd/Window.js
+++ b/zul/src/archive/web/js/zul/wnd/Window.js
@@ -1028,9 +1028,11 @@ zul.wnd.Window = zk.$extends(zul.Widget, {
 	setZindex: _zkf,
 	focus_: function (timeout) {
 		var cap = this.caption;
-		for (var w = this.firstChild; w; w = w.nextSibling)
-			if (w != cap && w.focus_(timeout))
-				return true;
+		if(!zk.mobile) { //Bug ZK-1314: avoid focus on input widget to show keyboard on ipad
+			for (var w = this.firstChild; w; w = w.nextSibling)
+				if (w != cap && w.focus_(timeout))
+					return true;
+		}
 		return cap && cap.focus_(timeout);
 	},
 	getZclass: function () {


### PR DESCRIPTION
http://tracker.zkoss.org/browse/ZK-1314
