### PR TITLE
Bug ZK-1227 NumberInputElement.formatNumber() should use dt.applyLocalizedPattern() instead of dt.applyPattern()

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -7,6 +7,7 @@ ZK 6.0.3
   ZK-1128: Use SerializableUiFactory with a portal environment will cause ClassCastException
   ZK-1303: listbox select mold with 1 rows onSelect event not fired for first item
   ZK-1298: Can not set composer name with <custom-attributes>
+  ZK-1227: NumberInputElement.formatNumber() should use dt.applyLocalizedPattern() instead of dt.applyPattern()
 
 * Upgrade Notes
   + The default names of a composer will still be assigned no matter you set a composerName by custom-attributes or not.

--- a/zktest/src/archive/test2/B60-ZK-1227.zul
+++ b/zktest/src/archive/test2/B60-ZK-1227.zul
@@ -1,0 +1,4 @@
+<zk>
+	Should not see any error message.<separator/>
+	<decimalbox value="1111.112" locale="pt" format="#.##0,0##" />
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -1396,6 +1396,7 @@ B60-ZK-1205.zul=B,M,Notification,onFloatUp
 B60-ZK-1176.zul=B,M,Button,Toolbarbutton,autodisable,setDisabled,onClick
 B60-ZK-1160.zul=B,M,Tab,Include
 B60-ZK-1303.zul=B,M,Listbox,Select
+B60-ZK-1227.zul=A,E,Decimalbox,Format,Locale
 
 ##
 # Features - 3.0.x version

--- a/zul/src/org/zkoss/zul/impl/NumberInputElement.java
+++ b/zul/src/org/zkoss/zul/impl/NumberInputElement.java
@@ -214,7 +214,7 @@ abstract public class NumberInputElement extends FormatInputElement {
 
 		String fmt = getFormat();
 		if (fmt == null) fmt = defaultFormat;
-		if (fmt != null) df.applyPattern(fmt);
+		if (fmt != null) df.applyLocalizedPattern(fmt); //Bug ZK-1227: apply localized pattern for decimalbox
 		return df.format(value);
 	}
 	/** Filters out non digit characters, such comma and whitespace,


### PR DESCRIPTION
http://tracker.zkoss.org/browse/ZK-1227
