### PR TITLE
Bug ZK-1289: Servlets.browser() causes null exception on Viewpad

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -15,6 +15,7 @@ ZK 6.0.3
   ZK-1276: Combobox does not sync the selected item
   ZK-1208: Clients.scrollIntoView don't work in Chrome browser
   ZK-1268: ZK bind children throw Unsupported child exception
+  ZK-1289: Servlets.browser() causes null exception on Viewpad
 
 * Upgrade Notes
   + The default names of a composer will still be assigned no matter you set a composerName by custom-attributes or not.

--- a/zweb/src/org/zkoss/web/servlet/Servlets.java
+++ b/zweb/src/org/zkoss/web/servlet/Servlets.java
@@ -530,7 +530,7 @@ public class Servlets {
 
 		String btype = type.substring(0, last);
 		Double vclient = getBrowser(userAgent, btype);
-		if (vclient == null && userAgent.indexOf(btype) < 0)
+		if (vclient == null && (userAgent.indexOf(btype + ("ie".equals(btype) ? ' ' : "")) < 0)) //Bug ZK-1289: for Viewpad and IE mixed bug
 			return false; //not matched
 		if (vtype == null)
 			return true; //not care about version


### PR DESCRIPTION
http://tracker.zkoss.org/browse/ZK-1289
