### PR TITLE
Add Cardlayout feature

### DIFF
--- a/zktest/src/archive/test2/Z60-Touch-041.zul
+++ b/zktest/src/archive/test2/Z60-Touch-041.zul
@@ -1,0 +1,14 @@
+<?page title="new page title" contentType="text/html;charset=UTF-8"?>
+<zk>
+<label multiline="true"><![CDATA[
+	0. "short distance" means smaller than 200px
+	1. swipe a short distance (right to left), it will transform to yellow block.
+	2. swipe a short distance, it will not transform to image.
+	3. swipe a distance (bigger than 200px), it will tranfrom to image.
+]]></label>
+<cardlayout width="600px" height="600px">
+	<image src="../img/sun.jpg" vflex="1" hflex="1" />
+	<div style="background-color:#FFFF00" vflex="1" hflex="1"/>
+	<image src="../img/sun.jpg" vflex="1" hflex="1" />
+</cardlayout>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -1976,3 +1976,4 @@ Z60-Touch-037.zul=Z60,A,E,Touch,Combobox,Autodrop,ScrollInput,Android,Pad
 Z60-Touch-038.zul=Z60,A,E,Touch,Listbox,ScrollIntoView,Android,Pad
 Z60-Touch-039.zul=Z60,A,E,Touch,DoubleClick,zoom,Pad
 Z60-Touch-040.zul=Z60,A,E,Touch,Combobox,PopupPosition,Android,Pad
+Z60-Touch-041.zul=Z60,A,E,Touch,Cardlayout,swipe,Android,Pad,swipe setting


### PR DESCRIPTION
When swipe on child component with specific class, it will ignore cardlayout swipe setting and use default swipe setting.
