### PR TITLE
Bug ZK-1341: Datebox in zh_TW locale with 'Long + Medium' format failed to assign correct value

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -18,6 +18,7 @@ ZK 6.0.3
   ZK-1322: Issue on timebox with null value
   ZK-1313: combobox dropdown changes document scroll height on iPad
   ZK-1348: First child tree node can't unfold sometimes
+  ZK-1341: Datebox in zh_TW locale with 'Long + Medium' format failed to assign correct value
 
 * Upgrade Notes
   + The default names of a composer will still be assigned no matter you set a composerName by custom-attributes or not.

--- a/zktest/src/archive/test2/B60-ZK-1341.zul
+++ b/zktest/src/archive/test2/B60-ZK-1341.zul
@@ -1,0 +1,8 @@
+<zk>
+	<label multiline="true">
+	1. Change default language of browser to zh_TW.
+	2. Change AM(上午)/PM(下午) in timebox.
+	3. Close the popup calendar and you should see correct date time in datebox.
+	</label>
+	<datebox format="long+medium" width="300px" />
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -1402,6 +1402,7 @@ B60-ZK-1315.zul=B,M,SizedByContent,Menupopup,Grid
 B60-ZK-1256.zul=B,M,Combobox,SelectedItem
 B60-ZK-1208.zul=A,M,ScrollIntoView,Chrome,Safari,Grid
 B60-ZK-1322.zul=A,M,Timebox,setValue
+B60-ZK-1341.zul=A,E,Datebox,timeFormat,Locale
 
 ##
 # Features - 3.0.x version

--- a/zul/src/archive/web/js/zul/db/datefmt.js
+++ b/zul/src/archive/web/js/zul/db/datefmt.js
@@ -14,6 +14,8 @@ it will be useful, but WITHOUT ANY WARRANTY.
 */
 (function () {
 	function _parseTextToArray(txt, fmt) {
+		if (fmt.indexOf('\'') > -1) //Bug ZK-1341: 'long+medium' format with single quote in zh_TW locale failed to parse AM/PM
+			fmt = fmt.replace(/'/g, '');
 		var ts = [], mindex = fmt.indexOf("MMM"), eindex = fmt.indexOf("EE"),
 			fmtlen = fmt.length, ary = [],
 			//mmindex = mindex + 3,


### PR DESCRIPTION
http://tracker.zkoss.org/browse/ZK-1341
