### PR TITLE
Bug fix: B60-ZK-1336

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -23,6 +23,7 @@ ZK 6.0.3
   ZK-1358: When I try to show a window with doOverlapped, doModal or doHighlighted my window don't appears
   ZK-1347: Including Checkbox inside MVVM Form causes Error writing 'checked' on type org.zkoss.zul.Checkbox crash
   ZK-1344: Collection binding will occur error when deleting entry
+  ZK-1336: Liferay 6.1 + JBoss 7.1 + ZK 6 : Cannot encode relative URLs
 
 * Upgrade Notes
   + The default names of a composer will still be assigned no matter you set a composerName by custom-attributes or not.

--- a/zweb/src/org/zkoss/web/servlet/http/Encodes.java
+++ b/zweb/src/org/zkoss/web/servlet/http/Encodes.java
@@ -34,6 +34,8 @@ import org.zkoss.lang.Library;
 import org.zkoss.lang.SystemException;
 import org.zkoss.util.logging.Log;
 
+import org.zkoss.web.portlet.RenderHttpServletRequest;
+import org.zkoss.web.portlet.RenderHttpServletResponse;
 import org.zkoss.web.servlet.Servlets;
 import org.zkoss.web.servlet.Charsets;
 import org.zkoss.web.util.resource.ExtendletContext;
@@ -507,6 +509,13 @@ public class Encodes {
 			uri = encodeURI(uri);
 		} else {
 			uri = encodeURI(uri.substring(0, j)) + uri.substring(j);
+		}
+		// B60-ZK-1336: Liferay required uri to begin with '/' or '://'
+		if (response instanceof RenderHttpServletResponse) {
+			RenderHttpServletRequest rhsRequest = (RenderHttpServletRequest) request;
+			if (!uri.startsWith("/") && !uri.startsWith("://")) {
+				uri = rhsRequest.getContextPath() + "/" + uri;
+			}
 		}
 		//encode
 		if (response instanceof HttpServletResponse)


### PR DESCRIPTION
- Liferay 6.1 + JBoss 7.1 + ZK 6 : Cannot encode relative URLs
- Fix by prepending relative URLs with context root of portlet
