### PR TITLE
Bug ZK-1380: Forward uri can't be "zk/*" on Tomcat 7

### DIFF
--- a/zk/src/archive/META-INF/web-fragment.xml
+++ b/zk/src/archive/META-INF/web-fragment.xml
@@ -48,10 +48,10 @@ Copyright (C) 2011 Potix Corporation. All Rights Reserved.
 		<servlet-name>DHtmlLayoutServlet</servlet-name>
 		<url-pattern>*.zhtml</url-pattern>
 	</servlet-mapping>
-	<servlet-mapping><!-- richlet -->
+	<!--<servlet-mapping> Bug ZK-1380: disabled richlet mapping since Tomcat 7.0.29 will load this setting by default
 		<servlet-name>DHtmlLayoutServlet</servlet-name>
 		<url-pattern>/zk/*</url-pattern>
-	</servlet-mapping>
+	</servlet-mapping>-->
 
 	<mime-mapping>
 		<extension>zhtml</extension>

--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -25,6 +25,7 @@ ZK 6.0.3
   ZK-1344: Collection binding will occur error when deleting entry
   ZK-1372: zk.stackUp not work with Firefox
   ZK-1368: the right edge of the textboxes split over to a new line when you specify a percentage width and set the mold to rounded
+  ZK-1380: Forward uri can't be "zk/*" on Tomcat 7
 
 * Upgrade Notes
   + The default names of a composer will still be assigned no matter you set a composerName by custom-attributes or not.


### PR DESCRIPTION
http://tracker.zkoss.org/browse/ZK-1380
