### PR TITLE
Bug fix: B60-ZK-1337

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -28,6 +28,7 @@ ZK 6.0.3
   ZK-1383: The value of Map.Entry returned from ListModelMap.getElementAt() don't support Serializable
   ZK-1380: Forward uri can't be "zk/*" on Tomcat 7
   ZK-1259: zul with hashmap not load key from a fx
+  ZK-1337: RenderHttpServletRequest/RenderHttpServletResponse's getInstance() cause ServletException when passed to RequestDispather on Liferay 6.1 + JBoss 7.1
 
 * Upgrade Notes
   + The default names of a composer will still be assigned no matter you set a composerName by custom-attributes or not.

--- a/zweb/src/org/zkoss/web/portlet/ServletPortletDispatcher.java
+++ b/zweb/src/org/zkoss/web/portlet/ServletPortletDispatcher.java
@@ -16,13 +16,18 @@ Copyright (C) 2006 Potix Corporation. All Rights Reserved.
 */
 package org.zkoss.web.portlet;
 
+import java.lang.reflect.Method;
+
+import javax.portlet.PortletException;
 import javax.portlet.PortletRequestDispatcher;
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
-import javax.portlet.PortletException;
-
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
 
 /**
  * A facade of a RequestDispatch for implementing PortletRequestDispatcher.
@@ -48,8 +53,46 @@ public class ServletPortletDispatcher implements PortletRequestDispatcher {
 	public void include(RenderRequest request, RenderResponse response)
 	throws PortletException, java.io.IOException {
 		try {
-			_rd.include(RenderHttpServletRequest.getInstance(request), 
-				RenderHttpServletResponse.getInstance(response));
+			// B60-ZK-1337: issues with RenderHttpServletRequest/RenderHttpServletResponse Wrapper
+			//   will cause ServletException: Original SevletRequest or wrapped original ServletRequest
+			//       not passed to RequestDispatcher in violation of SRV.8.2 and SRV.14.2.5.1
+			if (_rd instanceof PortletRequestDispatcher) {
+				((PortletRequestDispatcher)_rd).include(request, response);
+			} else {
+				if (request instanceof HttpServletRequest &&
+					response instanceof HttpServletResponse) {
+					_rd.include((HttpServletRequest)request, (HttpServletResponse)response);
+				} else {
+					Method m = null;
+
+					HttpServletRequest hreq = null;
+					try {
+						try {
+							m = request.getClass().getMethod("getHttpServletRequest");
+						} catch (NoSuchMethodException ex) {
+							m = request.getClass().getMethod("getRequest");
+						}
+						hreq = (HttpServletRequest)m.invoke(request);
+					} catch (Throwable ex) {
+					}
+					
+					HttpServletResponse hres = null;
+					try {
+						try {
+							m = response.getClass().getMethod("getHttpServletResponse");
+						} catch (NoSuchMethodException ex) {
+							m = response.getClass().getMethod("getResponse");
+						}
+						hres = (HttpServletResponse)m.invoke(response);
+					} catch (Throwable ex) {
+					}
+					
+					// To avoid casting exceptions when strict Servlet 2.5 compliance
+					// is turned off on JBoss/Tomcat servers
+					_rd.include(new HttpServletRequestWrapper(hreq), 
+							    new HttpServletResponseWrapper(hres));
+				}
+			}
 		} catch (ServletException ex) {
 			if (ex.getRootCause() != null) {
 			    throw new PortletException(ex.getRootCause());


### PR DESCRIPTION
- RenderHttpServletRequest/RenderHttpServletResponse Wrapper will cause ServletException: Original SevletRequest or wrapped original ServletRequest
  not passed to RequestDispatcher in violation of SRV.8.2 and SRV.14.2.5.1
- The issue occurs when a portlet contains errors in them (tested on Liferay 6.1 + JBoss 7.1)
