### PR TITLE
B50-ZK-1391: When a window is invisible at first, its top (or left) attribute takes no effect even we turn the window to be visible.

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -29,6 +29,7 @@ ZK 5.0.12
   ZK-1179: ZK Internationalization Labels doesn't work with liferay (portal env)
   ZK-1222: Popup component as tooltips fires multiple onOpen events
   ZK-1230: Listbox with rod only removes the first list item when setItemInvalid
+  ZK-1391: When a window is invisible at first, its top (or left) attribute takes no effect even we turn the window to be visible.
   
 	--------
 ZK 5.0.11

--- a/zktest/src/archive/test2/B50-ZK-1391.zul
+++ b/zktest/src/archive/test2/B50-ZK-1391.zul
@@ -1,0 +1,28 @@
+<zk> 
+	<window title="(150, NaN)" mode="overlapped" width="100px" height="100px"  
+	 id="winX_" left="150px"            visible="false" />
+	<window title="(NaN, 150)" mode="overlapped" width="100px" height="100px"  
+	 id="win_Y"             top="150px" visible="false" />
+	<window title="(150, 150)" mode="overlapped" width="100px" height="100px"  
+	 id="winXY" left="150px" top="150px" visible="false" />
+	<separator height="400px" />
+	<button label="show" >
+		<attribute name="onClick">
+			winX_.visible=true;
+			win_Y.visible=true;
+			winXY.visible=true;
+		</attribute>
+	</button>
+	<button label="hide">
+		<attribute name="onClick">
+			winX_.visible=false;
+			win_Y.visible=false;
+			winXY.visible=false;
+		</attribute>		
+	</button>
+	<separator />
+	<label multiline="true">
+	1. Initially, there is no window on the screen.
+	2. Click "show", there will appear 3 windows on position (150, 0), (0, 150), (150, 150) 
+	</label>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -1319,6 +1319,7 @@ B50-ZK-1118.zul=A,M,Listbox,Tree,sizedByContent,rows
 B50-ZK-1143.zul=A,M,Errorbox,Mobile
 B50-ZK-1230.zul=B,M,Listbox,ROD,EE
 B50-ZK-1222.zul=B,M,Popup,Tooltip
+B50-ZK-1391.zul=A,E,Window,overlapped,position
 
 ##
 # Features - 3.0.x version

--- a/zul/src/archive/web/js/zul/wnd/Window.js
+++ b/zul/src/archive/web/js/zul/wnd/Window.js
@@ -118,8 +118,13 @@ it will be useful, but WITHOUT ANY WARRANTY.
 			$n = zk(n);
 		if (!pos && (!n.style.top || !n.style.left)) {
 			var xy = $n.revisedOffset();
-			n.style.left = jq.px(xy[0]);
-			n.style.top = jq.px(xy[1]);
+			//ZK-1391: use revisedOffset() only if style doesn't specify left/top value
+			if (!n.style.left) {
+				n.style.left = jq.px(xy[0]);
+			}
+			if (!n.style.top) {
+				n.style.top = jq.px(xy[1]);
+			}			
 		} else if (pos == "parent")
 			_posByParent(wgt);
 


### PR DESCRIPTION
http://tracker.zkoss.org/browse/ZK-1391

It also affect ZK 6.0 / ZK 6.5
