### PR TITLE
Bug fixed ZK-2024: combobox bound selectedItem not updated on blur event

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -15,6 +15,7 @@ ZK 7.0.1
   ZK-2053: Listgroup checkmark wrong display
   ZK-2004: The selected Objects of the Chosenbox is incorrect after replace model
   ZK-2038: Grid is missing the bottom border for certain layout in IE9~11
+  ZK-2024: combobox bound selectedItem not updated on blur event
   
   --------
 ZK 7.0.0

--- a/zktest/src/archive/test2/B70-ZK-2024.zul
+++ b/zktest/src/archive/test2/B70-ZK-2024.zul
@@ -1,0 +1,25 @@
+<zk>
+	<div>
+		<div>
+			1. type 'se' in the combobox 
+		</div>
+		<div>
+			2. focus on the textbox, then the label should show 'Sverige' and the value should show 'SE'.
+		</div>
+	</div>
+	<hbox apply="org.zkoss.bind.BindComposer"
+		viewModel="@id('vm') @init('org.zkoss.zktest.test2.B70_ZK_2024_ViewModel')">
+		<combobox model="@init(vm.countries)"
+			selectedItem="@bind(vm.country)" autodrop="true"
+			autocomplete="true">
+			<template name="model">
+				<comboitem value="${each.code}" label="${each.code}"
+					description="${each.name}" />
+			</template>
+		</combobox>
+		<cell width="8em" valign="middle">
+			<label value="@load(vm.country.name)" />
+		</cell>
+		<textbox />
+	</hbox>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -1658,6 +1658,7 @@ B70-ZK-2050.zul=B,E,Listbox,Checkmark,IE8
 B70-ZK-2053.zul=B,E,Listbox,Listcell,Listgroup,Checkmark
 B70-ZK-2004.zul=B,E,Chosenbox,Model
 B70-ZK-2038.zul=B,E,Grid,Flex,Label,Div,Span,A,Vlayout,IE
+B70-ZK-2024.zul=B,E,Combobox,Autocomplete,Databind
 
 ##
 # Features - 3.0.x version

--- a/zktest/src/org/zkoss/zktest/test2/B70_ZK_2024_ViewModel.java
+++ b/zktest/src/org/zkoss/zktest/test2/B70_ZK_2024_ViewModel.java
@@ -1,0 +1,92 @@
+package org.zkoss.zktest.test2;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.zkoss.bind.annotation.Init;
+
+public class B70_ZK_2024_ViewModel {
+	private String code;
+	private String name;
+
+	public B70_ZK_2024_ViewModel() {
+	}
+			
+			
+	public B70_ZK_2024_ViewModel(String code, String name) {
+		this.code = code;
+		this.name = name;
+	}
+
+	public String getCode() {
+		return code;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setCode(String code) {
+		this.code = code;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	private List<B70_ZK_2024_ViewModel> countries;
+	private B70_ZK_2024_ViewModel country;
+
+	public List<B70_ZK_2024_ViewModel> getCountries() {
+		return countries;
+	}
+
+	public B70_ZK_2024_ViewModel getCountry() {
+		return country;
+	}
+
+	@Init
+	public void init() {
+		countries = Arrays.asList(new B70_ZK_2024_ViewModel[] {
+				//
+				new B70_ZK_2024_ViewModel("AT", "\u00D6sterreich"), //
+				new B70_ZK_2024_ViewModel("BE", "Belgi\u00EB"), //
+				new B70_ZK_2024_ViewModel("BG",
+						"\u0411\u044A\u043B\u0433\u0430\u0440\u0438\u044F"), //
+				new B70_ZK_2024_ViewModel("CH", "Suisse"), //
+				new B70_ZK_2024_ViewModel("CY",
+						"\u039A\u03CD\u03C0\u03C1\u03BF\u03C2"), //
+				new B70_ZK_2024_ViewModel("CZ", "\u010Cesk\u00E1 republika"), //
+				new B70_ZK_2024_ViewModel("DE", "Deutschland"), //
+				new B70_ZK_2024_ViewModel("DK", "Danmark"), //
+				new B70_ZK_2024_ViewModel("EE", "Eesti"), //
+				new B70_ZK_2024_ViewModel("ES", "Espa\u00F1a"), //
+				new B70_ZK_2024_ViewModel("FI", "Suomi"), //
+				new B70_ZK_2024_ViewModel("FR", "France"), //
+				new B70_ZK_2024_ViewModel("GB", "United Kingdom"), //
+				new B70_ZK_2024_ViewModel("GR",
+						"\u0395\u03BB\u03BB\u03AC\u03B4\u03B1"), //
+				new B70_ZK_2024_ViewModel("HU", "Magyarorsz\u00E1g"), //
+				new B70_ZK_2024_ViewModel("IE", "\u00C9ire"), //
+				new B70_ZK_2024_ViewModel("IS", "\u00CDsland"), //
+				new B70_ZK_2024_ViewModel("IT", "Italia"), //
+				new B70_ZK_2024_ViewModel("LT", "Lietuva"), //
+				new B70_ZK_2024_ViewModel("LU", "L\u00EBtzebuerg"), //
+				new B70_ZK_2024_ViewModel("LV", "Latvija"), //
+				new B70_ZK_2024_ViewModel("MT", "Malta"), //
+				new B70_ZK_2024_ViewModel("NL", "Nederland"), //
+				new B70_ZK_2024_ViewModel("NO", "Norge"), //
+				new B70_ZK_2024_ViewModel("PL", "Polska"), //
+				new B70_ZK_2024_ViewModel("PT", "Portugal"), //
+				new B70_ZK_2024_ViewModel("RO", "Rom\u00E2nia"), //
+				new B70_ZK_2024_ViewModel("SE", "Sverige"), //
+				new B70_ZK_2024_ViewModel("SI", "Slovenija"), //
+				new B70_ZK_2024_ViewModel("SK", "Sloensk\u00E1 republika") //
+				});
+	}
+
+	public void setCountry(
+			B70_ZK_2024_ViewModel country) {
+		this.country = country;
+	}
+}

--- a/zul/src/archive/web/js/zul/inp/Combobox.js
+++ b/zul/src/archive/web/js/zul/inp/Combobox.js
@@ -329,8 +329,12 @@ zul.inp.Combobox = zk.$extends(zul.inp.ComboWidget, {
 			return this._hilite({strict:true});
 
 		var sel = this._findItem(val, true);
-		if (sel || bDel || !this._autocomplete)
+		if (sel || bDel || !this._autocomplete) {
+			// ZK-2024: the value should have same case with selected label if autocomplete is enabled
+			if (sel && sel.getLabel().toLowerCase().startsWith(val.toLowerCase()) && this._autocomplete)
+				inp.value = sel.getLabel();
 			return this._hilite2(sel);
+		}
 
 		//autocomplete
 		val = val.toLowerCase();


### PR DESCRIPTION
http://tracker.zkoss.org/browse/ZK-2024

the value of combobox should have same case with selected label if autocomplete is enabled
