### PR TITLE
Bug fixed B65-ZK-2026: Datebox always displays the current year when blurred if format = "MM.yyyy"

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -165,6 +165,7 @@ Jul 02, 2013
   ZK-1822: Turkish locale problem during browser detection (on server side)
   ZK-1827: Component inside native component js error
   ZK-1834: Listbox scroll bug
+  ZK-2026: Datebox always displays the current year when blurred if format = "MM.yyyy"
   
   --------
 ZK 6.5.2

--- a/zktest/src/archive/test2/B65-ZK-2026.zul
+++ b/zktest/src/archive/test2/B65-ZK-2026.zul
@@ -1,0 +1,7 @@
+<window border="normal" width="500px">
+	<label multiline="true">
+		1. Pick a date with year other than the current year
+		2. After close the calendar control, the year should not changes to the current year.
+	</label>
+	<datebox format="MM.yyyy"/>
+</window>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -1639,6 +1639,7 @@ B65-ZK-2047.zul=A,E,PDF,Datebox,Shadow,VParent,Stackup
 B65-ZK-2004.zul=B,E,Chosenbox,Model
 B65-ZK-1552.zul=B,E,Bandbox,Combobox,Datebox,OnScroll
 B65-ZK-2035.zul=B,E,widget
+B70-ZK-2026.zul=B,E,Datebox,Format
 
 ##
 # Features - 3.0.x version

--- a/zul/src/archive/web/js/zul/db/datefmt.js
+++ b/zul/src/archive/web/js/zul/db/datefmt.js
@@ -205,7 +205,9 @@ zk.fmt.Date = {
 			hasHour1 = hasAM && (fmt.indexOf('h') > -1 || fmt.indexOf('K') > -1),
 			isAM,
 			ts = _parseTextToArray(txt, fmt),
-			isNumber = !isNaN(txt);
+			regexp = /.*\D.*/,
+			// ZK-2026: Don't use isNaN(), it will treat float as number.
+			isNumber = !regexp.test(txt);
 
 		if (!ts || !ts.length) return;
 		for (var i = 0, j = 0, offs = 0, fl = fmt.length; j < fl; ++j) {
@@ -225,8 +227,8 @@ zk.fmt.Date = {
 				var token = isNumber ? ts[0].substring(j - offs, k - offs) : ts[i++];
 				switch (cc) {
 				case 'y':
-					// ZK-1985:	token's length is less than the expected if has the parse error  
-					if (token && (token.length < len))
+					// ZK-1985: Determine if token's length is less than the expected when strict is true. 
+					if (strict && token && (token.length < len))
 						return;
 					
 					if (nosep) {
@@ -237,8 +239,8 @@ zk.fmt.Date = {
 						}
 					}
 					
-					// ZK-1985:	token contains non-digital word if has the parse error
-					if (token && token.match(/.*\D.*/))
+					// ZK-1985:	Determine if token contains non-digital word when strict is true.
+					if (strict && token && regexp.test(token))
 						return;
 
 					if (!isNaN(nv = _parseInt(token))) {
@@ -301,15 +303,15 @@ zk.fmt.Date = {
 						_parseToken(token, ts, --i, len);
 					break;
 				case 'd':
-					// ZK-1985:	token's length is less than expected if has the parse error
-					if (token && (token.length < len))
+					// ZK-1985:	Determine if token's length is less than expected when strict is true.
+					if (strict && token && (token.length < len))
 						return;
 					
 					if (nosep)
 						token = _parseToken(token, ts, --i, len);
 					
-					// ZK-1985:	token contains non-digital word if has the parse error
-					if (token && token.match(/.*\D.*/))
+					// ZK-1985:	Determine if token contains non-digital word when strict is true.
+					if (strict && token && regexp.test(token))
 						return;
 					
 					if (!isNaN(nv = _parseInt(token))) {
@@ -323,8 +325,8 @@ zk.fmt.Date = {
 				case 'h':
 				case 'K':
 				case 'k':
-					// ZK-1985:	token's length is less than expected if has the parse error
-					if (token && (token.length < len))
+					// ZK-1985:	Determine if token's length is less than the expected when strict is true.
+					if (strict && token && (token.length < len))
 						return;
 					
 					if (hasHour1 ? (cc == 'H' || cc == 'k'): (cc == 'h' || cc == 'K'))
@@ -332,8 +334,8 @@ zk.fmt.Date = {
 					if (nosep)
 						token = _parseToken(token, ts, --i, len);
 					
-					// ZK-1985:	token contains non-digital word if has the parse error
-					if (token && token.match(/.*\D.*/))
+					// ZK-1985:	Determine if token contains non-digital word when strict is true.
+					if (strict && token && regexp.test(token))
 						return;
 					
 					if (!isNaN(nv = _parseInt(token)))
@@ -343,15 +345,15 @@ zk.fmt.Date = {
 				case 'm':
 				case 's':
 				case 'S':
-					// ZK-1985:	token's length is less than expected if has the parse error
-					if (token && (token.length < len))
+					// ZK-1985:	Determine if token's length is less than the expected when strict is true.
+					if (strict && token && (token.length < len))
 						return;
 					
 					if (nosep)
 						token = _parseToken(token, ts, --i, len);
 					
-					// ZK-1985:	token contains non-digital word if has the parse error
-					if (token && token.match(/.*\D.*/))
+					// ZK-1985:	Determine if token contains non-digital word when strict is true.
+					if (strict && token && regexp.test(token))
 						return;
 					
 					if (!isNaN(nv = _parseInt(token))) {


### PR DESCRIPTION
http://tracker.zkoss.org/browse/ZK-2026
