### PR TITLE
Bug fixed B65-ZK-1852: Processing indicator briefly displayed in non-localized text

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -47,6 +47,7 @@ ZK 6.5.5
   ZK-1892: Error when calling setCoords() in Area widget
   ZK-1954: Vertical scroll appear when remove last listitem from Listbox
   ZK-1965: zksandbox service.zul throw method getNamespace() not found exception
+  ZK-1852: Processing indicator briefly displayed in non-localized text
   
   --------
 ZK 6.5.4

--- a/zktest/src/archive/test2/B65-ZK-1852.zul
+++ b/zktest/src/archive/test2/B65-ZK-1852.zul
@@ -1,0 +1,14 @@
+<window>
+	Click the button, should show "處理中".
+	<separator/>
+	<button label="Click">
+		<attribute name="onClick"><![CDATA[
+			Locale locale = org.zkoss.util.Locales.getLocale("zh_TW");
+		    session.setAttribute(org.zkoss.web.Attributes.PREFERRED_LOCALE, locale);
+		    execution.sendRedirect(null);
+		]]></attribute>
+	</button>
+	<script><![CDATA[
+		zk.log(jq(".z-temp .z-loading-indicator").text());
+	]]></script>
+</window>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -1643,6 +1643,7 @@ B70-ZK-2026.zul=B,E,Datebox,Format
 B65-ZK-1880.zul=B,E,Menu,IE9,IE10,IE11
 B65-ZK-1892.zul=B,E,Area,JSconsole
 B65-ZK-1954.zul=B,E,Listbox,Listitem,SelectWidget,Scrollbar
+B65-ZK-1852.zul=B,E,Locale,Processing,Page
 
 ##
 # Features - 3.0.x version


### PR DESCRIPTION
http://tracker.zkoss.org/browse/ZK-1852
