### PR TITLE
B70-ZK-2068: In Portallayout, width property set via a controller is reset to the value at page load on browser window resize

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -35,6 +35,7 @@ ZK 7.0.1
   ZK-1852: Processing indicator briefly displayed in non-localized text
   ZK-1953: Checkmark in listheader is checked when nothing in the listbox
   ZK-2074: native scroll bar disappearing with frozen on browser resize
+  ZK-2068: In Portallayout, width property set via a controller is reset to the value at page load on browser window resize
 
 * Upgrade Notes
   + Rename the implemetation class of label loader from org.zkoss.util.resource.impl.LabelLoader

--- a/zktest/src/archive/test2/B70-ZK-2068.zul
+++ b/zktest/src/archive/test2/B70-ZK-2068.zul
@@ -1,0 +1,20 @@
+<?page title="Portallayout" contentType="text/html;charset=UTF-8"?>
+<zk>
+	<window border="normal" title="Portallayout">
+		<label multiline="true">
+			1.Click "resize",the yellow area will change width.
+			2.Resize browser window, the width of yellow area will not be changed.
+		</label>
+		<button id="btn" label="resize" onClick="click()"/>
+		<portallayout>
+	    	<portalchildren id="child1" style="background-color:yellow;" height="450px"  width="30%"/>
+	    	<portalchildren style="background-color:blue;" height="450px" width="30%"/>
+	        <portalchildren style="background-color:green;" height="450px"  width="30%"/>
+		</portallayout>
+		<zscript>
+			public void click(){
+			  	child1.setWidth(25+"px");
+			}
+		</zscript>
+	</window>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -1681,6 +1681,7 @@ B70-ZK-2065.zul=B,E,HTML5,Validation,Macro,Cache
 B70-ZK-2071.zul=B,E,Meshwidget,Auxhead,Listhead,Columns,Treecols,Frozen,Scrollbar
 B70-ZK-1953.zul=B,E,SelectWidget,Checkmark,Listbox,Listhead
 B70-ZK-2072.zul=B,E,MeshWidget,Scrollbar,Frozen
+B70-ZK-2068.zul=B,E,Portallayout,PortalChildren
 
 ##
 # Features - 3.0.x version


### PR DESCRIPTION
http://tracker.zkoss.org/browse/ZK-2068
