### PR TITLE
Bug fixed B65-ZK-2105: EventQueue still sending request even it is removed by EventQueues.remove() API when using PollingServerPush

### DIFF
--- a/zk/src/org/zkoss/zk/ui/impl/DesktopImpl.java
+++ b/zk/src/org/zkoss/zk/ui/impl/DesktopImpl.java
@@ -1374,7 +1374,8 @@ public class DesktopImpl implements Desktop, DesktopCtrl, java.io.Serializable {
 		synchronized(enablers) {
 			boolean enablersEmptyBefore = enablers.isEmpty();
 			if(enable) {
-				if(!enablers.add(enabler)) {
+				// B76-ZK-2105: Do not add null enabler.
+				if(enabler != null && !enablers.add(enabler)) {
 					log.debug("trying to enable already enabled serverpush by: " + enabler);
 					return false;
 				}
@@ -1382,7 +1383,8 @@ public class DesktopImpl implements Desktop, DesktopCtrl, java.io.Serializable {
 					return enableServerPush0(serverPush, enable);
 				}
 			} else { 
-				if(!enablers.remove(enabler)) {
+				// B76-ZK-2105: Do not remove null enabler.
+				if(enabler != null && !enablers.remove(enabler)) {
 					log.debug("trying to disable already disabled serverpush by: " + enabler);
 					return false;
 				}

--- a/zk/src/org/zkoss/zk/ui/impl/PollingServerPush.java
+++ b/zk/src/org/zkoss/zk/ui/impl/PollingServerPush.java
@@ -227,6 +227,9 @@ public class PollingServerPush implements ServerPush {
 	}
 
 	public void onPiggyback() {
+		// B65-ZK-2105: Need to check if desktop is null.
+		if (_desktop == null)
+			return;
 		final Configuration config = _desktop.getWebApp().getConfiguration();
 		long tmexpired = 0;
 		for (int cnt = 0; !_pending.isEmpty();) {

--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -6,6 +6,7 @@ ZK 6.5.6
   ZK-2080: Chosenbox with ListSubModel not working if using template to render data
   ZK-2091: Copy-paste large value in doublebox get error.
   ZK-2056: XSS Vulnerability in AuUploader
+  ZK-2105: EventQueue still sending request even it is removed by EventQueues.remove() API when using PollingServerPush
   
   --------
 ZK 6.5.5

--- a/zktest/src/archive/test2/B65-ZK-2105.zul
+++ b/zktest/src/archive/test2/B65-ZK-2105.zul
@@ -1,0 +1,28 @@
+<zk>
+  <window title="Server Push" border="normal" apply="org.zkoss.zktest.test2.B65_ZK_2105">
+		<label multiline="true">
+		1. Click the button
+		2. Wait 5 seconds.
+		3. Should see true.
+		</label>
+      
+    <button id="startLongOp" label="Click" />
+    <separator/>
+    <label id="msg"/>
+		<script type="text/javascript" defer="true"><![CDATA[
+zk.afterMount(function () {
+	var oldFn = zAu.cmd0.script,
+			arr = ["cpsp.start", "cpsp.stop"],
+	  	i = 0,
+	  	result = true;
+	zAu.cmd0.script = function (script) {
+		oldFn.apply(this, arguments);
+		result = result && (script.indexOf(arr[i]) != -1);
+		i = i + 1;
+		if (i == 2) 
+			zk.Widget.$(jq('$msg')[0]).setValue(result);
+		};
+});
+		]]></script>
+  </window>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -1647,6 +1647,7 @@ B65-ZK-1852.zul=B,E,Locale,Processing,Page
 B65-ZK-2080.zul=A,E,Chosenbox,Template,ListSubModel
 B65-ZK-2091.zul=A,E,Doublebox,Parser,JSON
 B65-ZK-2056.zul=B,E,Security,Button,Fileupolad,AuUploader,XSS
+B65-ZK-2105.zul=B,E,ServerPush,EventQueue
 
 ##
 # Features - 3.0.x version

--- a/zktest/src/org/zkoss/zktest/test2/B65_ZK_2105.java
+++ b/zktest/src/org/zkoss/zktest/test2/B65_ZK_2105.java
@@ -1,0 +1,62 @@
+package org.zkoss.zktest.test2;
+
+import org.zkoss.zk.ui.Desktop;
+import org.zkoss.zk.ui.Executions;
+import org.zkoss.zk.ui.event.Event;
+import org.zkoss.zk.ui.event.EventListener;
+import org.zkoss.zk.ui.event.EventQueue;
+import org.zkoss.zk.ui.event.EventQueues;
+import org.zkoss.zk.ui.select.SelectorComposer;
+import org.zkoss.zk.ui.select.annotation.Listen;
+import org.zkoss.zk.ui.select.annotation.Wire;
+import org.zkoss.zk.ui.select.annotation.WireVariable;
+import org.zkoss.zul.Label;
+import org.zkoss.zul.Vbox;
+import org.zkoss.zul.Window;
+
+/**
+ * @author Vincent
+ * 
+ */
+public class B65_ZK_2105 extends SelectorComposer<Window> {
+
+	private static final long serialVersionUID = -3344321079575322219L;
+	
+	@WireVariable
+	private Desktop desktop;
+	
+	@Wire
+	private Vbox inf;
+	
+	@Listen("onClick = #startLongOp")
+	public void doClick() {
+		if (EventQueues.exists("longop")) {
+			return; // busy
+		}
+		
+		((org.zkoss.zk.ui.sys.DesktopCtrl) desktop).enableServerPush(new org.zkoss.zk.ui.impl.PollingServerPush(2000, 5000, -1));
+		final EventQueue<Event> eq = EventQueues.lookup("longop");
+
+		final EventListener<Event> longOp = new EventListener<Event>() {
+			public void onEvent(Event evt) {
+				if ("doLongOp".equals(evt.getName())) {
+					org.zkoss.lang.Threads.sleep(1000);
+					eq.publish(new Event("endLongOp", null));
+				}
+			}
+		};
+		
+		final EventListener<Event> callback = new EventListener<Event>() {
+			public void onEvent(Event evt) throws InterruptedException {
+				if ("endLongOp".equals(evt.getName())) {
+					EventQueues.remove("longop");
+					org.zkoss.lang.Threads.sleep(1000);
+					Executions.deactivate(desktop);
+				}
+			}
+		};
+		
+		eq.subscribe(longOp, callback);
+		eq.publish(new Event("doLongOp"));
+	}
+}


### PR DESCRIPTION
http://tracker.zkoss.org/browse/ZK-2105
