### PR TITLE
B65-ZK-2111: Button fileupload sometimes not work when using strong CSS font style

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -7,6 +7,7 @@ ZK 6.5.6
   ZK-2091: Copy-paste large value in doublebox get error.
   ZK-2056: XSS Vulnerability in AuUploader
   ZK-2105: EventQueue still sending request even it is removed by EventQueues.remove() API when using PollingServerPush
+  ZK-2111: Button fileupload sometimes not work when using strong CSS font style
   
   --------
 ZK 6.5.5

--- a/zktest/src/archive/test2/B65-ZK-2111.zul
+++ b/zktest/src/archive/test2/B65-ZK-2111.zul
@@ -1,0 +1,8 @@
+<?page title="Button fileupload CSS" contentType="text/html;charset=UTF-8"?>
+<zk>
+	<style src="/test2/css/B65-ZK-2111-Style.css" />
+	<label value="Click upload button, then the file selector should work fine."/>
+	<window width="200px" title="Button fileupload CSS" border="normal">
+		<button upload="true, native" label="upload"/>
+	</window>
+</zk>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -1648,6 +1648,7 @@ B65-ZK-2080.zul=A,E,Chosenbox,Template,ListSubModel
 B65-ZK-2091.zul=A,E,Doublebox,Parser,JSON
 B65-ZK-2056.zul=B,E,Security,Button,Fileupolad,AuUploader,XSS
 B65-ZK-2105.zul=B,E,ServerPush,EventQueue
+B65-ZK-2111.zul=B,E,Button,Upload,Style
 
 ##
 # Features - 3.0.x version

--- a/zktest/src/archive/test2/css/B65-ZK-2111-Style.css
+++ b/zktest/src/archive/test2/css/B65-ZK-2111-Style.css
@@ -1,0 +1,3 @@
+* {
+	font-size:14px !important;
+}

--- a/zul/src/archive/web/js/zul/Upload.js
+++ b/zul/src/archive/web/js/zul/Upload.js
@@ -155,8 +155,13 @@ zul.Upload = zk.$extends(zk.Object, {
 		delete this._formDetached;
 
 		//B50-3304877: autodisable and Upload
-		if (!wgt._autodisable_self)
-			this.sync();
+		if (!wgt._autodisable_self) {
+			var self = this;
+			//B65-ZK-2111: Sync later to prevent the external style change button offset height/width.
+			setTimeout(function () {
+				self.sync();
+			}, 50);
+		}
 
 		var outer = this._outer = parent ? parent.lastChild : ref.nextSibling,
 			inp = outer.firstChild.firstChild;


### PR DESCRIPTION
http://tracker.zkoss.org/browse/ZK-2111
