### PR TITLE
Bug fixed ZK-2169: CometServerPush.getStartScript() should include org.z...

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -13,6 +13,7 @@ ZK 6.5.6
   ZK-2138: vflex="1" not working properly with groupbox
   ZK-2140: Multiple select with Shift key does not work properly
   ZK-2143: Filedownload should support chinese file name
+  ZK-2169: CometServerPush.getStartScript() should include org.zkoss.zkex.ui.comet.smartconnection.disabled in ee version
   
   --------
 ZK 6.5.5

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -1655,6 +1655,7 @@ B65-ZK-2133.zul=A,E,Listbox,SelectMold,Option,Model,Selection,Multiple
 B65-ZK-2138.zul=A,E,Groupbox,Vflex,Anima,Size
 B65-ZK-2140.zul=A,E,Listbox,Multiple,SelectWidget,ToggleSelect,Focus,ShiftClick
 B65-ZK-2143.zul=A,E,FileDownload,UserAgent,URLEncoder
+B65-ZK-2169.zul=B,E,CometServerPush,Smartconnection,EE
 ##
 # Features - 3.0.x version
 ##


### PR DESCRIPTION
...koss.zkex.ui.comet.smartconnection.disabled in ee version

http://tracker.zkoss.org/browse/ZK-2169
