### PR TITLE
Bug fixed ZK-2169: CometServerPush.getStartScript() should include org.z...

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -73,11 +73,13 @@ ZK 7.0.1
   ZK-2069: Validation error message does not scroll with component.
   ZK-2158: Tab can be click on blank area next to last tab (IE9 only)
   ZK-2157: Listheaders not showing if no listitems and Listbox is sized by content
+  ZK-2169: CometServerPush.getStartScript() should include org.zkoss.zkex.ui.comet.smartconnection.disabled in ee version
 
 * Upgrade Notes
   + Rename the implemetation class of label loader from org.zkoss.util.resource.impl.LabelLoader
   to org.zkoss.util.resource.impl.LabelLoaderImpl and create an interface named
   org.zkoss.util.resource.impl.LabelLoader instead.
+  + the default value of org.zkoss.zkex.ui.comet.smartconnection.disabled changes from false to true
   
   --------
 ZK 7.0.0


### PR DESCRIPTION
...koss.zkex.ui.comet.smartconnection.disabled in ee version

http://tracker.zkoss.org/browse/ZK-2169
