### PR TITLE
Bug fixed B7-2184: Navitem does not fire onClick event when clicked in tablet

### DIFF
--- a/zkdoc/release-note
+++ b/zkdoc/release-note
@@ -78,6 +78,7 @@ ZK 7.0.1
   ZK-2165: Some items are not displayed in paging tree
   ZK-2172: Biglistbox with frozenCols missing data
   ZK-2117: South does not calculate correct size
+  ZK-2184: Navitem does not fire onClick event when clicked in tablet
 
 * Upgrade Notes
   + Rename the implemetation class of label loader from org.zkoss.util.resource.impl.LabelLoader

--- a/zktest/src/archive/test2/B70-ZK-2184.zul
+++ b/zktest/src/archive/test2/B70-ZK-2184.zul
@@ -1,0 +1,9 @@
+<window title="Click Navitem Label" border="normal" width="400px" height="300px">
+<navbar id="nb" collapsed="false">
+	<navitem label="Click me!" onClick='msg.appendChild(new Label("[click]"));' iconSclass="z-icon-flag"/>
+</navbar>
+Click on the "Click me!" in tablet, it would show [click].
+<separator />
+<div id="msg">
+</div>
+</window>

--- a/zktest/src/archive/test2/config.properties
+++ b/zktest/src/archive/test2/config.properties
@@ -1721,6 +1721,7 @@ B70-ZK-2157.zul=A,E,Listbox,Tree,Grid,Mesh,Header
 B70-ZK-2100.zul=B,E,Tabbox,Nest,Orient
 B70-ZK-2165.zul=A,E,Tree,ROD,Paging,PagSize,InitRodSize
 B70-ZK-2117.zul=A,M,Borderlayout,Hflex,Vflex,Min
+B70-ZK-2184.zul=B,E,Navitem,onClick,Tablet
 
 ##
 # Features - 3.0.x version


### PR DESCRIPTION
http://tracker.zkoss.org/browse/ZK-2184
